### PR TITLE
Adds a Today's Quote option to the shortcode

### DIFF
--- a/inc/class-quotes-collection-db.php
+++ b/inc/class-quotes-collection-db.php
@@ -69,6 +69,20 @@ class Quotes_Collection_DB {
 		else return false;
 	}
 
+	/** Fetches a single quote from the database, one per day **/
+	public function get_todays_quote($args = array()) {
+		$args['orderby'] = 'quote_id';
+		if($quote_array = $this->get_quotes($args)) {
+			return $quote_array[$this->today_val()%sizeof($quote_array)];
+		} else {
+			return false;
+		}
+	}
+
+	/** Determines a serial value for today, based on time() **/
+	public function today_val() {
+		return floor(time() / (60 * 60 * 24));
+	}
 	/** 
 	 * Fetches quote entry with a specific ID 
 	 *

--- a/inc/class-quotes-collection-quote.php
+++ b/inc/class-quotes-collection-quote.php
@@ -34,6 +34,11 @@ class Quotes_Collection_Quote {
 		return $quotescollection_db->get_quote($args);
 	}
 
+	public static function todays_quote( $args ) {
+		global $quotescollection_db;
+		return $quotescollection_db->get_todays_quote($args);
+	}
+
 	public static function with_id( $quote_id ) {
 		return self::with_condition( array( 'quote_id' => $quote_id ) );
 	}

--- a/inc/class-quotes-collection-shortcode.php
+++ b/inc/class-quotes-collection-shortcode.php
@@ -36,10 +36,11 @@ class Quotes_Collection_Shortcode {
 			'after' => '</blockquote>',
 			'before_attribution' => '<footer class="attribution">&mdash;&nbsp;',
 			'after_attribution' => '</footer>',
+			'todays_quote' => false,
 		), $atts );
 		extract($atts);
 		
-		if( $ajax_refresh && $ajax_refresh !== 'false' ) {
+		if( ($ajax_refresh && $ajax_refresh !== 'false') || ($todays_quote && $todays_quote !== 'false') ) {
 				$atts['echo'] = 0;
 				if(
 					($auto_refresh == 1 || $auto_refresh === true || $auto_refresh == 'true')

--- a/inc/class-quotes-collection.php
+++ b/inc/class-quotes-collection.php
@@ -197,6 +197,7 @@ class Quotes_Collection {
 			'before_attribution' => '<div class="attribution">&mdash;&nbsp;',
 			'after_attribution' => '</div>',
 			'echo'           => 1,
+			'todays_quote'	=> 0,
 		);
 
 		// Merge with default values
@@ -207,6 +208,7 @@ class Quotes_Collection {
 		$show_source = ( true == $args['show_source'] && 'false' !== $args['show_source'] )? 1 : 0;
 		$ajax_refresh = ( false == $args['ajax_refresh'] || 'false' === $args['ajax_refresh'] )? 0 : 1;
 		$auto_refresh = 0;
+		$todays_quote = ( false == $args['todays_quote'] || 'false' === $args['todays_quote'] )? 0 : 1;
 		if( $args['auto_refresh'] ) {
 			if( is_numeric( $args['auto_refresh'] ) ) {
 				$auto_refresh = $args['auto_refresh'];
@@ -262,7 +264,12 @@ class Quotes_Collection {
 
 		// And fetch the quote, only if dynamic fetch is off
 		if( !$dynamic_fetch ) {
-			if ( $quote = Quotes_Collection_Quote::with_condition( $condition ) ) {
+			if($todays_quote) {
+				$quote = Quotes_Collection_Quote::todays_quote( $condition );
+			} else {
+				$quote = Quotes_Collection_Quote::with_condition( $condition );
+			}
+			if ( $quote ) {
 				$curr_quote_id = $quote->quote_id;
 				$display = $quote->output_format(
 					array(


### PR DESCRIPTION
I wanted a way to offer a daily quote from the database, so I added a todays_quote=true attribute to the shortcode. To pick a quote, it takes the number of quotes returned by the db query, and mods it into a day-of-the-unix-epoch value. This means that given any specific collection of quotes, it will cycle through them one per day, no matter how often you refresh the page.

 For example:

`[quotecoll todays_quote=true show_source=false tags="favorite, quoted, other"]`

It's not extensively tested, but works on my website. See the top section of the homepage: [larrywitzel.com](https://www.larrywitzel.com)